### PR TITLE
[fix](#11):Knowledge move file can`t to move to root directory

### DIFF
--- a/mrk-service/mrk-service-chat/src/main/java/com/magicrepokit/chat/service/impl/KnowledgeServiceImpl.java
+++ b/mrk-service/mrk-service-chat/src/main/java/com/magicrepokit/chat/service/impl/KnowledgeServiceImpl.java
@@ -44,6 +44,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 创建文件夹或文件
+     *
      * @param createDTO 创建文件夹或文件参数
      * @return 创建结果
      */
@@ -64,16 +65,16 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
             pathId.add(parentId);
             knowledge.setPathId(pathId);
         }
-        if(knowledge.getType().equals(KnowledgeConstant.FILE)){
+        if (knowledge.getType().equals(KnowledgeConstant.FILE)) {
             //1.索引为空生成索引
-            if(ObjectUtil.isEmpty(knowledge.getIndexName())){
+            if (ObjectUtil.isEmpty(knowledge.getIndexName())) {
                 knowledge.setIndexName(mkIndexName());
             }
             //2.匹配度
             knowledge.setMinScore(createDTO.getMinScore());
             //3.返回结果
             knowledge.setMaxResult(createDTO.getMaxResult());
-        }else{
+        } else {
             knowledge.setIndexName(null);
             knowledge.setImageUrl(null);
         }
@@ -83,6 +84,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 文件或文件夹列表
+     *
      * @param knowledgeListDTO 查询参数
      * @return 文件或文件夹列表
      */
@@ -102,20 +104,21 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
         }
         //3.查询自己的 //TODO 后期根据权限控制
         MRKUser user = AuthUtil.getUser();
-        if(ObjectUtil.isNull(user)){
+        if (ObjectUtil.isNull(user)) {
             return null;
         }
         //4.类型
-        if(ObjectUtil.isNotEmpty(knowledgeListDTO.getType())){
-            lambdaQueryWrapper.eq(Knowledge::getType,knowledgeListDTO.getType());
+        if (ObjectUtil.isNotEmpty(knowledgeListDTO.getType())) {
+            lambdaQueryWrapper.eq(Knowledge::getType, knowledgeListDTO.getType());
         }
-        lambdaQueryWrapper.eq(Knowledge::getCreateUser,user.getUserId());
+        lambdaQueryWrapper.eq(Knowledge::getCreateUser, user.getUserId());
         PageResult<Knowledge> knowledgePageResult = selectPage(knowledgeListDTO, lambdaQueryWrapper);
         return knowledgePageResult.convert(knowledgeConverter::entityToKnowledgeListVO);
     }
 
     /**
      * 根据父节点id查询当前路径
+     *
      * @param parentId 父id
      * @return 当前路径
      */
@@ -136,7 +139,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
             return result;
         }
         List<Knowledge> knowledgeList = getKnowledgeListByIds(pathId);
-        if(ObjectUtil.isEmpty(knowledgeList)){
+        if (ObjectUtil.isEmpty(knowledgeList)) {
             return null;
         }
         List<KnowledgePathVO> result = knowledgeConverter.entityListToPathVOList(knowledgeList);
@@ -146,6 +149,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 移动文件或文件夹
+     *
      * @param knowledgeMoveDTO 移动文件或文件夹参数
      * @return 移动结果
      */
@@ -154,7 +158,9 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
     public boolean move(KnowledgeMoveDTO knowledgeMoveDTO) {
         //1.查询父id是否存在
         Long parentId = knowledgeMoveDTO.getParentId();
-        if (parentId != null && !checkIsExistById(parentId)) {
+        if (ObjectUtil.isEmpty(parentId)|| Objects.equals(parentId,0L)) {
+            parentId = 0L;
+        } else if (!checkIsExistById(parentId)) {
             throw new ServiceException(ChatResultCode.PARENT_ID_NOT_EXIST);
         }
         //2.查询当前id是否存在
@@ -169,7 +175,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
         }
         Knowledge knowledgeByParentId = getKnowledgeById(parentId);
         List<Long> newPath = knowledgeByParentId.getPathId();
-        if(ObjectUtil.isNull(newPath)){
+        if (ObjectUtil.isNull(newPath)) {
             newPath = new ArrayList<>();
         }
         newPath.add(parentId);
@@ -180,7 +186,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
         for (Knowledge knowledge : allChildren) {
             List<Long> pathId = knowledge.getPathId();
             //替换旧路径
-            replayOldPath(pathId,id,newPath);
+            replayOldPath(pathId, id, newPath);
             knowledge.setPathId(pathId);
         }
         allChildren.add(knowledgeById);
@@ -190,13 +196,14 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 删除文件或文件夹
+     *
      * @param knowledgeIds 文件或文件夹id
      * @return 删除结果
      */
     @Override
     public boolean delete(String knowledgeIds) {
         List<Long> ids = StringUtil.splitToLong(knowledgeIds, StrUtil.COMMA);
-        if(ObjectUtil.isEmpty(ids)){
+        if (ObjectUtil.isEmpty(ids)) {
             return false;
         }
         for (Long id : ids) {
@@ -206,11 +213,11 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
                 return true;
             }
             //2.查询是否有子节点
-            if(checkIsChildById(id)){
+            if (checkIsChildById(id)) {
                 throw new ServiceException(ChatResultCode.HAS_CHILD);
             }
             //3.如果是文件查询是否有文件
-            if(knowledgeDetailService.checkHasFile(id)){
+            if (knowledgeDetailService.checkHasFile(id)) {
                 throw new ServiceException(ChatResultCode.HAS_FILE);
             }
         }
@@ -220,6 +227,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 文件处理
+     *
      * @param knowledgeProcessDTO 文件处理参数
      * @return 文件处理结果
      */
@@ -228,13 +236,13 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
         //1.查询当前id是否存在
         Knowledge knowledgeById = getProcessKnowledge(knowledgeProcessDTO.getId());
         String fileName = knowledgeProcessDTO.getFileName();
-        if(knowledgeDetailService.checkIsFileExist(knowledgeProcessDTO.getId(),fileName)){
+        if (knowledgeDetailService.checkIsFileExist(knowledgeProcessDTO.getId(), fileName)) {
             throw new ServiceException(ChatResultCode.FILE_EXIST);
         }
         //2.获取文件后缀名
         String fileNameSuffix = getFileNameSuffix(fileName);
         //3.判断是否txt,md,pdf
-        if(!checkIsTxtMdPdf(fileNameSuffix)){
+        if (!checkIsTxtMdPdf(fileNameSuffix)) {
             throw new ServiceException(ChatResultCode.FILE_TYPE_ERROR);
         }
         //5.保存文件信息
@@ -246,7 +254,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
         knowledgeDetail.setType(fileNameSuffix);
         boolean save = knowledgeDetailService.save(knowledgeDetail);
         //6.推送流程任务处理
-        KnowledgeProcessEvent knowledgeProcessEvent = new KnowledgeProcessEvent(knowledgeById.getIndexName(),knowledgeDetail);
+        KnowledgeProcessEvent knowledgeProcessEvent = new KnowledgeProcessEvent(knowledgeById.getIndexName(), knowledgeDetail);
         applicationEventPublisher.publishEvent(knowledgeProcessEvent);
         return save;
     }
@@ -254,6 +262,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 文件内容上传处理(多文件处理)
+     *
      * @param knowledgeProcessBatchDTO
      * @return
      */
@@ -261,18 +270,18 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
     public boolean processBatch(KnowledgeProcessBatchDTO knowledgeProcessBatchDTO) {
         Knowledge processKnowledge = getProcessKnowledge(knowledgeProcessBatchDTO.getId());
         List<KnowledgeProcessBatchDTO.FileVO> files = knowledgeProcessBatchDTO.getFiles();
-        if(ObjectUtil.isEmpty(files)){
+        if (ObjectUtil.isEmpty(files)) {
             throw new ServiceException(ChatResultCode.FILE_NOT_EXIST);
         }
         //1.批量检验文件是否存在
         List<String> fileNames = files.stream().map(KnowledgeProcessBatchDTO.FileVO::getFileName).collect(Collectors.toList());
-        if(knowledgeDetailService.checkIsFileBatchExist(knowledgeProcessBatchDTO.getId(),fileNames)){
+        if (knowledgeDetailService.checkIsFileBatchExist(knowledgeProcessBatchDTO.getId(), fileNames)) {
             throw new ServiceException(ChatResultCode.FILE_EXIST);
         }
         //2.批量检验文件类型
         for (KnowledgeProcessBatchDTO.FileVO file : files) {
             String fileNameSuffix = getFileNameSuffix(file.getFileName());
-            if(!checkIsTxtMdPdf(fileNameSuffix)){
+            if (!checkIsTxtMdPdf(fileNameSuffix)) {
                 throw new ServiceException(ChatResultCode.FILE_TYPE_ERROR);
             }
         }
@@ -289,7 +298,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
         }
         boolean saveBatch = knowledgeDetailService.saveBatch(knowledgeDetails);
         //4.推送流程任务处理
-        KnowledgeProcessEvent knowledgeProcessEvent = new KnowledgeProcessEvent(processKnowledge.getIndexName(),knowledgeDetails);
+        KnowledgeProcessEvent knowledgeProcessEvent = new KnowledgeProcessEvent(processKnowledge.getIndexName(), knowledgeDetails);
         applicationEventPublisher.publishEvent(knowledgeProcessEvent);
         return saveBatch;
     }
@@ -297,6 +306,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 文件详情
+     *
      * @param id 文件id
      * @return 文件详情
      */
@@ -304,43 +314,44 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
     public KnowledgeFileListVO detailFile(Long id) {
         //1.查询当前id是否存在
         Knowledge knowledgeById = getKnowledgeById(id);
-        if(ObjectUtil.isNull(knowledgeById)){
+        if (ObjectUtil.isNull(knowledgeById)) {
             return null;
         }
-        if(!knowledgeById.getType().equals(KnowledgeConstant.FILE)){
+        if (!knowledgeById.getType().equals(KnowledgeConstant.FILE)) {
             return null;
         }
-        return knowledgeConverter.entityToKnowledgeFileVO(knowledgeById,knowledgeDetailService.listByKnowledgeId(id));
+        return knowledgeConverter.entityToKnowledgeFileVO(knowledgeById, knowledgeDetailService.listByKnowledgeId(id));
     }
 
     /**
      * 文件处理状态详情列表
+     *
      * @return 文件处理状态详情列表
      */
     @Override
     public List<KnowledgeFileVO> listFileStatus() {
         //查询未完成的文件
-        List<KnowledgeDetail> listNotCompleted =  knowledgeDetailService.listNotCompleted();
-        if(ObjectUtil.isEmpty(listNotCompleted)){
+        List<KnowledgeDetail> listNotCompleted = knowledgeDetailService.listNotCompleted();
+        if (ObjectUtil.isEmpty(listNotCompleted)) {
             return null;
         }
         List<Long> knowledgeIds = listNotCompleted.stream().map(KnowledgeDetail::getKnowledgeId).collect(Collectors.toList());
         List<Knowledge> knowledgeList = getKnowledgeListByIds(knowledgeIds);
-        return knowledgeConverter.entityListToKnowledgeFileVOList(listNotCompleted,knowledgeList);
+        return knowledgeConverter.entityListToKnowledgeFileVOList(listNotCompleted, knowledgeList);
     }
 
     @Override
     public List<KnowledgeFileVO> listFile(Long knowledgeId) {
         //1.查询当前id是否存在
         Knowledge knowledgeById = getKnowledgeById(knowledgeId);
-        if(ObjectUtil.isNull(knowledgeById)){
+        if (ObjectUtil.isNull(knowledgeById)) {
             return null;
         }
-        if(!knowledgeById.getType().equals(KnowledgeConstant.FILE)){
+        if (!knowledgeById.getType().equals(KnowledgeConstant.FILE)) {
             return null;
         }
         List<KnowledgeDetail> knowledgeDetails = knowledgeDetailService.listByKnowledgeId(knowledgeId);
-        return knowledgeConverter.entityListToKnowledgeFileVOList(knowledgeDetails,knowledgeById);
+        return knowledgeConverter.entityListToKnowledgeFileVOList(knowledgeDetails, knowledgeById);
     }
 
     @Override
@@ -348,7 +359,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
     public boolean deleteFile(String knowledgeIds) {
         List<Long> ids = StringUtil.splitToLong(knowledgeIds, StrUtil.COMMA);
         List<Knowledge> knowledgeList = getKnowledgeFileList(ids);
-        if(ObjectUtil.isEmpty(knowledgeList)){
+        if (ObjectUtil.isEmpty(knowledgeList)) {
             return true;
         }
         List<Long> knowledgeIdList = knowledgeList.stream().map(Knowledge::getId).collect(Collectors.toList());
@@ -356,7 +367,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
         //1.删除文件
         boolean flag = knowledgeDetailService.deleteByKnowledgeIds(knowledgeIdList);
         //2.删除索引
-        if(!elasticOperation.deleteIndex(indexName)){
+        if (!elasticOperation.deleteIndex(indexName)) {
             throw new ServiceException(ChatResultCode.DELETE_INDEX_ERROR);
         }
         return flag;
@@ -365,27 +376,27 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
     @Override
     public boolean checkIsFile(Long knowledgeId) {
         return this.count(new LambdaQueryWrapper<>(Knowledge.class)
-                .eq(Knowledge::getId,knowledgeId)
-                .eq(Knowledge::getType,KnowledgeConstant.FILE)) > 0;
+                .eq(Knowledge::getId, knowledgeId)
+                .eq(Knowledge::getType, KnowledgeConstant.FILE)) > 0;
     }
 
     @Override
     public KnowledgeVO updateByDto(KnowledgeUpdateDTO updateDTO) {
         Knowledge knowledge = getById(updateDTO.getId());
-        if(ObjectUtil.isNull(knowledge)){
+        if (ObjectUtil.isNull(knowledge)) {
             throw new ServiceException(ChatResultCode.ID_NOT_EXIST);
         }
-        if(ObjectUtil.isNotEmpty(updateDTO.getName())){
+        if (ObjectUtil.isNotEmpty(updateDTO.getName())) {
             knowledge.setName(updateDTO.getName());
         }
-        if(knowledge.getType().equals(KnowledgeConstant.FILE)){
-            if(ObjectUtil.isNotEmpty(updateDTO.getImageUrl())){
+        if (knowledge.getType().equals(KnowledgeConstant.FILE)) {
+            if (ObjectUtil.isNotEmpty(updateDTO.getImageUrl())) {
                 knowledge.setImageUrl(updateDTO.getImageUrl());
             }
-            if(ObjectUtil.isNotEmpty(updateDTO.getMinScore())){
+            if (ObjectUtil.isNotEmpty(updateDTO.getMinScore())) {
                 knowledge.setMinScore(updateDTO.getMinScore());
             }
-            if(ObjectUtil.isNotEmpty(updateDTO.getMaxResult())){
+            if (ObjectUtil.isNotEmpty(updateDTO.getMaxResult())) {
                 knowledge.setMaxResult(updateDTO.getMaxResult());
             }
         }
@@ -398,15 +409,15 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
         //1.查询当前id是否存在
         KnowledgeDetail knowledgeDetailById = knowledgeDetailService.getById(knowledgeDetailId);
         Knowledge knowledgeById = getKnowledgeById(knowledgeDetailById.getKnowledgeId());
-        if(ObjectUtil.isNull(knowledgeDetailById)){
+        if (ObjectUtil.isNull(knowledgeDetailById)) {
             return true;
         }
-        if(!knowledgeDetailById.getStatus().equals(KnowledgeConstant.FAIL)){
+        if (!knowledgeDetailById.getStatus().equals(KnowledgeConstant.FAIL)) {
             return true;
         }
         knowledgeDetailById.setStatus(KnowledgeConstant.NOT_STARTED);
         //2.推送流程任务处理
-        KnowledgeProcessEvent knowledgeProcessEvent = new KnowledgeProcessEvent(knowledgeById.getIndexName(),knowledgeDetailById);
+        KnowledgeProcessEvent knowledgeProcessEvent = new KnowledgeProcessEvent(knowledgeById.getIndexName(), knowledgeDetailById);
         applicationEventPublisher.publishEvent(knowledgeProcessEvent);
         knowledgeDetailService.saveOrUpdate(knowledgeDetailById);
         return true;
@@ -414,6 +425,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 生成索引名
+     *
      * @return 索引名
      */
     private String mkIndexName() {
@@ -422,8 +434,9 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 判断是否txt,md,pdf
+     *
      * @param fileNameSuffix 文件后缀名
-     * @return 是否txt,md,pdf
+     * @return 是否txt, md, pdf
      */
     private boolean checkIsTxtMdPdf(String fileNameSuffix) {
         return "txt".equals(fileNameSuffix) || "md".equals(fileNameSuffix) || "pdf".equals(fileNameSuffix);
@@ -432,8 +445,9 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 判断是否txt,md,pdf
+     *
      * @param fileName 文件
-     * @return 是否txt,md,pdf
+     * @return 是否txt, md, pdf
      */
     private String getFileNameSuffix(String fileName) {
         return fileName.substring(fileName.lastIndexOf(".") + 1);
@@ -441,8 +455,9 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 重放旧路径
-     * @param pathId 旧路径
-     * @param id 当前id
+     *
+     * @param pathId  旧路径
+     * @param id      当前id
      * @param newPath 新路径
      */
     private void replayOldPath(List<Long> pathId, Long id, List<Long> newPath) {
@@ -471,6 +486,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 检测文件是否存在
+     *
      * @param id 文件id
      * @return 是否存在
      */
@@ -480,6 +496,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 检测文件是否存在子节点
+     *
      * @param id 文件id
      * @return 是否存在
      */
@@ -489,6 +506,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 根据id查询文件
+     *
      * @param id 文件id
      * @return 文件
      */
@@ -498,12 +516,13 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 根据id查询文件列表
+     *
      * @param ids 文件id
      * @return 文件
      */
     private List<Knowledge> getKnowledgeListByIds(List<Long> ids) {
-        List<Knowledge> unsortedKnowledgeList  = this.list(new LambdaQueryWrapper<Knowledge>().in(Knowledge::getId, ids));
-        if(ObjectUtil.isEmpty(unsortedKnowledgeList)){
+        List<Knowledge> unsortedKnowledgeList = this.list(new LambdaQueryWrapper<Knowledge>().in(Knowledge::getId, ids));
+        if (ObjectUtil.isEmpty(unsortedKnowledgeList)) {
             return null;
         }
         // 创建一个ID到知识对象的映射
@@ -517,6 +536,7 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 查询所有子节点
+     *
      * @param parentId 父节点id
      * @return 所有子节点
      */
@@ -535,18 +555,19 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 文件处理-获取文件
+     *
      * @param id 文件知识库id
      * @return
      */
     private Knowledge getProcessKnowledge(Long id) {
-        if(ObjectUtil.isNull(id)){
+        if (ObjectUtil.isNull(id)) {
             throw new ServiceException(ChatResultCode.ID_NOT_EXIST);
         }
         Knowledge knowledgeById = getKnowledgeById(id);
-        if(ObjectUtil.isNull(knowledgeById)){
+        if (ObjectUtil.isNull(knowledgeById)) {
             throw new ServiceException(ChatResultCode.ID_NOT_EXIST);
         }
-        if(!knowledgeById.getType().equals(KnowledgeConstant.FILE)){
+        if (!knowledgeById.getType().equals(KnowledgeConstant.FILE)) {
             throw new ServiceException(ChatResultCode.TYPE_NOT_FILE);
         }
         return knowledgeById;
@@ -554,16 +575,17 @@ public class KnowledgeServiceImpl extends BaseServiceImpl<KnowledgeMapper, Knowl
 
     /**
      * 获取知识库文件列表
+     *
      * @param ids
      * @return
      */
     private List<Knowledge> getKnowledgeFileList(List<Long> ids) {
         List<Knowledge> knowledgeListByIds = getKnowledgeListByIds(ids);
-        if(ObjectUtil.isEmpty(knowledgeListByIds)){
+        if (ObjectUtil.isEmpty(knowledgeListByIds)) {
             return null;
         }
         List<Knowledge> collect = knowledgeListByIds.stream().filter(knowledge -> knowledge.getType().equals(KnowledgeConstant.FILE)).collect(Collectors.toList());
-        if(ObjectUtil.isEmpty(collect)){
+        if (ObjectUtil.isEmpty(collect)) {
             return null;
         }
         return collect;


### PR DESCRIPTION
### Bug Description
Knowledge move file can`t to move to root directory。

---
### Cause
When moving the knowledge base, the check for the target ID ignored the situation of the root directory.

---
### Processing Result
Added id review for the target directory as the root directory.

---